### PR TITLE
Update and rename scroll.md to scroll_milestone.md

### DIFF
--- a/events/scroll_milestone.md
+++ b/events/scroll_milestone.md
@@ -1,6 +1,6 @@
-# Scroll
+# Scroll Milestone
 
-Fire when a user scrolls past a certain scroll depth. The built-in event fires automatically on 90% scroll depth, but customizing will allow for more control of triggering logic for user scroll engagement.
+Fire when a user scrolls past a certain scroll depth. The built-in `scroll` event can be set up to automatically on 90% scroll depth, but this event will allow for more milestones to be recorded.
 
 ## Javascript Code
 
@@ -8,7 +8,7 @@ Fire when a user scrolls past a certain scroll depth. The built-in event fires a
 window.dataLayer = window.dataLayer || [];
 dataLayer.push({ event_data: null });  // Clear the previous event_data object.
 dataLayer.push({
-  event: '<scroll>',
+  event: 'scroll_milestone',
   event_data: {
     percent_scrolled: '<percent_scrolled>'
   }


### PR DESCRIPTION
I'm a little concerned that firing the scroll event will mess up built-in reporting that expects that event to only fire when 100% scroll depth has been reached...and therefore we should update the event name to be scroll_milestone instead. @jcottriel-sdi thoughts on this?