### PR TITLE
Update print_coupon to coupon_print

### DIFF
--- a/events/coupon/print_coupon.md
+++ b/events/coupon/print_coupon.md
@@ -12,7 +12,7 @@ Fire whenever a user attempts to print a coupon.
 window.dataLayer = window.dataLayer || [];
 dataLayer.push({ event_data: null });  // Clear the previous event_data object.
 dataLayer.push({
-  event: 'coupon_print',
+  event: 'print_coupon',
   event_data: {
     coupons: '<coupons>', // REQUIRED | string - delimited (~) | ex. couponName1~couponName2~couponName3	
   }
@@ -23,4 +23,4 @@ dataLayer.push({
 
 |Field|Type|Required|Description|Example|Pattern|Min Length|Max Length|Minimum|Maximum|Multiple Of|
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-|coupons|delimited string|required|A delimited string of coupons that the user selected and is now downloading or printing.|couponName1\~couponName2\~couponName3|
+|`event_data.coupons`|delimited string|required|A delimited string of coupons that the user selected and is now downloading or printing.|`couponName1~couponName2~couponName3`|


### PR DESCRIPTION
`coupon_print` is already being used in the code. Easier at this point to update documentation than to update code.

See Q1 in https://confluence.jnj.com/display/ADAQ/GA4+Doc+Questions